### PR TITLE
hero-image追加と諸々

### DIFF
--- a/src/components/HeaderMenu.js
+++ b/src/components/HeaderMenu.js
@@ -2,12 +2,11 @@ import React from 'react';
 import { makeStyles } from '@material-ui/styles';
 import { Link } from 'gatsby';
 import { colors } from 'libs/colors';
-import { useMediaQuery } from '@material-ui/core';
 
 const useStyles = makeStyles(theme => ({　
-  root: props => props.matches ? {
+  root: props => props.isApeared ? {
     height: 76,
-    paddingRight: 64,
+    paddingRight: 40,
     fontSize: 24,
     display: 'flex',
     justifyContent: 'space-between',
@@ -21,7 +20,7 @@ const useStyles = makeStyles(theme => ({　
     fontWeight: 'bold',
     textDecoration: 'none',
     width: 120,
-    marginLeft: 32,
+    marginLeft: 24,
     padding: 8
   },
   current: {
@@ -38,10 +37,11 @@ const useStyles = makeStyles(theme => ({　
 export default props => {
   const {
     currentPage,
-    pageLinks
+    pageLinks,
+    isApeared
   } = props;
-  const matches = useMediaQuery('(min-width: 1024px)');
-  const classes = useStyles({ matches });
+  
+  const classes = useStyles({ isApeared });
 
   return (
     <div className={classes.root}>

--- a/src/components/HeaderMenu.js
+++ b/src/components/HeaderMenu.js
@@ -2,15 +2,18 @@ import React from 'react';
 import { makeStyles } from '@material-ui/styles';
 import { Link } from 'gatsby';
 import { colors } from 'libs/colors';
+import { useMediaQuery } from '@material-ui/core';
 
-const useStyles = makeStyles(theme => ({
-  root: {
+const useStyles = makeStyles(theme => ({　
+  root: props => props.matches ? {
     height: 76,
     paddingRight: 64,
     fontSize: 24,
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center'
+  } : {
+    display: 'none'
   },
   link: {
     display: 'flex',
@@ -37,7 +40,8 @@ export default props => {
     currentPage,
     pageLinks
   } = props;
-  const classes = useStyles();
+  const matches = useMediaQuery('(min-width: 1024px)');
+  const classes = useStyles({ matches });
 
   return (
     <div className={classes.root}>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,12 +1,13 @@
 import { Link } from "gatsby";
 import React from "react";
 import { makeStyles } from '@material-ui/styles';
+import { useMediaQuery } from '@material-ui/core';
 import Image from 'components/Image';
 import HeaderMenu from "components/HeaderMenu";
 import { colors } from 'libs/colors';
 
 const useStyles = makeStyles(theme => ({
-  root: {
+  header: {
     height: 144,
     padding: 0,
     paddingLeft: 32,
@@ -19,15 +20,16 @@ const useStyles = makeStyles(theme => ({
     color: colors.brown,
     textDecoration: 'none'
   },
-  logoText: {
+  logoText: props => props.matches ? {
     margin: '0 0 8px 0',
     fontSize: 24,
+  } : {
+    margin: '0 0 4px 0',
+    fontSize: 14,
   },
-  logoImage: {
-    height: 64,
-    width: 371.52,
-    padding: 0,
-    margin: 0,
+  hero: {
+    width: '100vw',
+    marginBottom: 160
   }
 }));
 
@@ -36,21 +38,44 @@ export default props => {
     pageLinks,
     currentPage
   } = props;
-  const classes = useStyles();
+  const matches = useMediaQuery('(min-width: 1024px)');
+  const classes = useStyles({ matches });
+
   return (
-    <header className={classes.root}>
-      <Link to='/' className={classes.logo}>
-        <p className={classes.logoText}>
-          高齢者・障がい者・障がい児多世代通所型(共生型)
-        </p>
-        <div className={classes.logoImage}>
-          <Image filename='logo.png'/>
+    <div className={classes.root}>
+      <header className={classes.header}>
+        <Link to='/' className={classes.logo}>
+          <p className={classes.logoText}>
+            高齢者・障がい者・障がい児多世代通所型(共生型)
+          </p>
+          <Image
+            filename='logo.png'
+            style={matches ? {
+              height: 64,
+              width: 371.5
+            } : {
+              height: 40,
+              width: 232.2
+            }}
+          />
+        </Link>
+        <HeaderMenu
+          currentPage={currentPage}
+          pageLinks={pageLinks}
+          isApeared={matches}
+        />
+      </header>
+      {currentPage.toString() === '/' &&
+        <div className={classes.hero}>
+          <Image
+            filename='top_image.jpg'
+            style={{
+              height: matches ? '80vh' : '40vh',
+              width: '100vw'
+            }}
+          />
         </div>
-      </Link>
-      <HeaderMenu
-        currentPage={currentPage}
-        pageLinks={pageLinks}
-      />
-    </header>
+      }
+    </div>
   );
 }

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -15,6 +15,9 @@ export default props => (
                 sizes(maxWidth: 600) {
                   ...GatsbyImageSharpSizes
                 }
+                fluid {
+                  ...GatsbyImageSharpFluid
+                }
               }
             }
           }
@@ -28,12 +31,14 @@ export default props => (
       });
       if (!image) { return null; }
 
-      const imageSizes = image.node.childImageSharp.sizes;
+      // const imageSizes = image.node.childImageSharp.sizes;
+      const fluid = image.node.childImageSharp.fluid;
       return (
         <Img
           alt={props.alt}
-          sizes={imageSizes}
-          style={{ margin: 0 }}
+          fluid={fluid}
+          // sizes={imageSizes}
+          style={props.style}
         />
       );
     }}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,8 +7,7 @@ import { colors } from "libs/colors";
 
 const useStyles = makeStyles(theme => ({
   title: {
-    color: colors.black,
-    backgroundColor: colors.white
+    color: colors.black
   }
 }));
 


### PR DESCRIPTION
## hero-imageと合わせてヘッダー調整
フォントサイズとか余白を実装しながら調整していってこんな感じにした。
1024ちょうどの時はちょっときもいかな〜くらいかな。

- 1440px
![image](https://user-images.githubusercontent.com/39250854/70383528-a4530a00-19b2-11ea-8dc5-30a2356bf596.png)

- 1024px
![image](https://user-images.githubusercontent.com/39250854/70383533-b765da00-19b2-11ea-8d66-790e232bc3a4.png)

- 425px
![image](https://user-images.githubusercontent.com/39250854/70383553-11ff3600-19b3-11ea-884c-e6bed647eea1.png)

## レスポンシブ対応
クラス全体でもプロパティ単体に対しても適用可能.
```js
import { makeStyles } from '@material-ui/styles';
import { useMediaQuery } from '@material-ui/core';

const useStyles = makeStyles(theme => ({　
  root: props => props.matches ? {
    height: 76,
    paddingRight: 64,
    display: 'flex','
  } : {
    display: 'none'
  },
  text: {
    paddingLeft: props => props.matches ? 32 : 16
  }
}));

export default props => {
  const matches = useMediaQuery('(min-width: 1024px)');
  const classes = useStyles({ matches });
  
  return ...
}
```

## 画像のサイズ指定
imge.jsの内容を修正して, `div`で囲わなくても`width, height`を指定できるようにした.  
でも`margin`使う時は囲わないと効かないみたい.
```js
import Image from 'components/Image';

...

<Image
  filename='top_image.jpg'
  style={{
    height: matches ? '80vh' : '40vh',
    width: '100vw'
  }}
/>
```
